### PR TITLE
fix: eventsource disconnecting on server errors (http 5xx)

### DIFF
--- a/views/bus.html
+++ b/views/bus.html
@@ -5,21 +5,36 @@
     <link rel="stylesheet" href="/public/css/common.css">
     <link rel="stylesheet" href="/public/css/bus.css">
     <script>
-      const events = new EventSource('/subscribe');
-      events.addEventListener('slbus', (bus) => {
-        const data = JSON.parse(bus.data);
-        let fourhtml = '<h3> 4:an </h3>';
-        let otherhtml = '<h3> Others </h3>';
-        data.four.forEach((bus) => {
-          fourhtml += `<div class='bus'><span class='busnr'>${bus.id}</span><span class='dest'>${bus.destination}</span><span class='bustime'>${bus.display}</span></div>`;
+      let events;
+      let backoff = 1;
+      function setupEvents() {
+        events = new EventSource('/subscribe');
+        events.addEventListener('slbus', (bus) => {
+          const data = JSON.parse(bus.data);
+          let fourhtml = '<h3> 4:an </h3>';
+          let otherhtml = '<h3> Others </h3>';
+          data.four.forEach((bus) => {
+            fourhtml += `<div class='bus'><span class='busnr'>${bus.id}</span><span class='dest'>${bus.destination}</span><span class='bustime'>${bus.display}</span></div>`;
+          });
+          data.other.forEach((bus) => {
+            otherhtml += `<div class='bus'><span class='busnr'>${bus.id}</span><span class='dest'>${bus.destination}</span><span class='bustime'>${bus.display}</span></div>`;
+          });
+          document.getElementById("bus4").innerHTML = fourhtml;
+          document.getElementById("busother").innerHTML = otherhtml;
+          document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
         });
-        data.other.forEach((bus) => {
-          otherhtml += `<div class='bus'><span class='busnr'>${bus.id}</span><span class='dest'>${bus.destination}</span><span class='bustime'>${bus.display}</span></div>`;
+        events.addEventListener('open', () => {
+          backoff = 1;
         });
-        document.getElementById("bus4").innerHTML = fourhtml;
-        document.getElementById("busother").innerHTML = otherhtml;
-        document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
-      });
+        events.addEventListener('error', () => {
+          // Manually handle errors because it doesn't retry on 502
+          events.close();
+          setTimeout(setupEvents, backoff * 1000);
+          backoff = Math.min(backoff * 2, 60);
+        });
+      }
+
+      setupEvents();
     </script>
   </head>
   <body>

--- a/views/index.html
+++ b/views/index.html
@@ -3,14 +3,28 @@
   <head>
     <title> Metasl2.0 </title>
     <script>
-      const events = new EventSource('/subscribe');
-      events.addEventListener('stats', (stats) => {
-        const data = JSON.parse(stats.data);
-        document.getElementById('requests').innerHTML = data.requests;
-        document.getElementById('time').innerHTML = new Date();
-        document.getElementById('nrofclients').innerHTML = data.nrofclients;
-      });
+      let events;
+      let backoff = 1;
+      function setupEvents() {
+        events = new EventSource('/subscribe');
+        events.addEventListener('stats', (stats) => {
+          const data = JSON.parse(stats.data);
+          document.getElementById('requests').innerHTML = data.requests;
+          document.getElementById('time').innerHTML = new Date();
+          document.getElementById('nrofclients').innerHTML = data.nrofclients;
+        });
+        events.addEventListener('open', () => {
+          backoff = 1;
+        });
+        events.addEventListener('error', () => {
+          // Manually handle errors because it doesn't retry on 502
+          events.close();
+          setTimeout(setupEvents, backoff * 1000);
+          backoff = Math.min(backoff * 2, 60);
+        });
+      }
 
+      setupEvents();
     </script>
   </head>
   <body>

--- a/views/metro.html
+++ b/views/metro.html
@@ -5,29 +5,44 @@
     <link rel="stylesheet" href="/public/css/common.css">
     <link rel="stylesheet" href="/public/css/metro.css">
     <script>
-      const events = new EventSource('/subscribe');
-      events.addEventListener('slmetro', (metro) => {
-        const data = JSON.parse(metro.data);
-        document.getElementById("g1tcontent").innerHTML = `<span class='dest'>${data.north[0].id} ${data.north[0].destination}</span><span class='time'>${data.north[0].display}</span>`;
-        document.getElementById("g2tcontent").innerHTML = `<span class='dest'>${data.south[0].id} ${data.south[0].destination}</span><span class='time'>${data.south[0].display}</span>`;
-        let northbottom = '';
-        let southbottom = '';
-        for (i = 1; i < Math.min(data.north.length, 4); i++) {
-          northbottom += `${data.north[i].id} ${data.north[i].destination} ${data.north[i].display}`;
-          if (i + 1 !== data.north.length) {
-             northbottom += "&nbsp; &nbsp; &nbsp";
+      let events;
+      let backoff = 1;
+      function setupEvents() {
+        events = new EventSource('/subscribe');
+        events.addEventListener('slmetro', (metro) => {
+          const data = JSON.parse(metro.data);
+          document.getElementById("g1tcontent").innerHTML = `<span class='dest'>${data.north[0].id} ${data.north[0].destination}</span><span class='time'>${data.north[0].display}</span>`;
+          document.getElementById("g2tcontent").innerHTML = `<span class='dest'>${data.south[0].id} ${data.south[0].destination}</span><span class='time'>${data.south[0].display}</span>`;
+          let northbottom = '';
+          let southbottom = '';
+          for (i = 1; i < Math.min(data.north.length, 4); i++) {
+            northbottom += `${data.north[i].id} ${data.north[i].destination} ${data.north[i].display}`;
+            if (i + 1 !== data.north.length) {
+               northbottom += "&nbsp; &nbsp; &nbsp";
+            }
           }
-        }
-        for (i = 1; i < Math.min(data.south.length, 4); i++) {
-          southbottom += `${data.south[i].id} ${data.south[i].destination} ${data.south[i].display}`;
-          if (i + 1 !== data.south.length) {
-             southbottom += "&nbsp; &nbsp; &nbsp";
+          for (i = 1; i < Math.min(data.south.length, 4); i++) {
+            southbottom += `${data.south[i].id} ${data.south[i].destination} ${data.south[i].display}`;
+            if (i + 1 !== data.south.length) {
+               southbottom += "&nbsp; &nbsp; &nbsp";
+            }
           }
-        }
-        document.getElementById("g1bcontent").innerHTML = northbottom;
-        document.getElementById("g2bcontent").innerHTML = southbottom;
-        document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
-      });
+          document.getElementById("g1bcontent").innerHTML = northbottom;
+          document.getElementById("g2bcontent").innerHTML = southbottom;
+          document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
+        });
+        events.addEventListener('open', () => {
+          backoff = 1;
+        });
+        events.addEventListener('error', () => {
+          // Manually handle errors because it doesn't retry on 502
+          events.close();
+          setTimeout(setupEvents, backoff * 1000);
+          backoff = Math.min(backoff * 2, 60);
+        });
+      }
+
+      setupEvents();
     </script>
   </head>
   <body>

--- a/views/tram.html
+++ b/views/tram.html
@@ -5,16 +5,31 @@
     <link rel="stylesheet" href="/public/css/common.css">
     <link rel="stylesheet" href="/public/css/tram.css">
     <script>
-      const events = new EventSource('/subscribe');
-      events.addEventListener('sltram', (tram) => {
-        const data = JSON.parse(tram.data);
-        let tramhtml = '<h3> Roslagsbanan </h3>'
-        data.forEach((tram) => {
-          tramhtml += `<div><span class='linenr'>${tram.id}</span><span class='dest'>${tram.destination}</span> <span class='time'>${tram.display}</span></div>`;
+      let events;
+      let backoff = 1;
+      function setupEvents() {
+        events = new EventSource('/subscribe');
+        events.addEventListener('sltram', (tram) => {
+          const data = JSON.parse(tram.data);
+          let tramhtml = '<h3> Roslagsbanan </h3>'
+          data.forEach((tram) => {
+            tramhtml += `<div><span class='linenr'>${tram.id}</span><span class='dest'>${tram.destination}</span> <span class='time'>${tram.display}</span></div>`;
+          });
+          document.getElementById("tram").innerHTML = tramhtml;
+          document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
         });
-        document.getElementById("tram").innerHTML = tramhtml;
-        document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
-      });
+        events.addEventListener('open', () => {
+          backoff = 1;
+        });
+        events.addEventListener('error', () => {
+          // Manually handle errors because it doesn't retry on 502
+          events.close();
+          setTimeout(setupEvents, backoff * 1000);
+          backoff = Math.min(backoff * 2, 60);
+        });
+      }
+
+      setupEvents();
     </script>
   </head>
   <body>


### PR DESCRIPTION
In Chromium, EventSource retries on connection errors but not when the server returns a 5XX error code. This can happen when the server is being redeployed and the proxy returns 502 temporarily, leaving the TV in Meta with outdated data until it is restarted.

This commit implements an retry mechanism with exponential back-off, starting with 1 second and doubling until reaching a maximum of 60 seconds between tries.