### PR TITLE
Add metro-tram page

### DIFF
--- a/public/css/bus.css
+++ b/public/css/bus.css
@@ -1,22 +1,15 @@
-#bus4 {
-    float: left;
-}
-
-#busother {
-    float: right;
-}
-
 .buses {
     height: 80vh;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    & > div {
+        flex: 1;
+    }
 }
 
-.buslist {
-    width: 50vw;
-    display: inline-block;
-    background-color: white;
-}
-
-.buslist>h3 {
+.buslist > h3 {
     background-color: #222;
     color: white;
     text-align: center;
@@ -24,40 +17,37 @@
     font-size: 7vh;
 }
 
-.buslist>.bus>span {
-    font-size: 5vh;
-}
-
-.buslist>.bus {
-    position: relative;
-}
-.buslist>.bus>span.busnr {
-    width: 5vw;
-    display: inline-block;
-    padding-right: 1vw;
-    padding-left: 1vw;
-}
-
-.buslist>.bus>span.dest {
-
-}
-
-.buslist>.bus>span.bustime {
-    position: absolute;
-    right: 0;
-    padding-right: 1vw;
-}
-.buslist>.bus:nth-child(odd) {
-    background-color: #222;
-}
-.buslist>.bus:nth-child(even) {
-    background-color: #333;
-}
 .buslist > .bus {
+    position: relative;
     color: #fff;
-    width: 45vw;
-    padding: 0 5vw 0 0;
+    padding: 0 2vw 0 1vw;
+    background-color: #333;
+    font-size: 5vh;
+    display: grid;
+    grid-template-columns: 6vw 1fr;
+
+    &:nth-child(odd) {
+        background-color: #222; /* TODO: maybe change to better color */
+    }
+
+    & span.bustime {
+        position: absolute;
+        right: 2vw;
+    }
 }
-.buslist:last-child >.bus {
-    padding: 0 0 0 5vw !important;
+.buslist:last-child > .bus {
+    padding: 0 0 0 2vw;
+
+    & span.bustime {
+        right: 1vw;
+    }
+}
+
+span.dest {
+    padding-left: 2vw;
+    display: inline-block;
+}
+
+span.busnr {
+    display: inline-block;
 }

--- a/public/css/metro-tram.css
+++ b/public/css/metro-tram.css
@@ -1,0 +1,86 @@
+.container {
+    height: 80vh;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    & > div {
+        flex: 1;
+    }
+}
+
+h3 {
+    background-color: #222;
+    color: white;
+    text-align: center;
+    padding: 2vh 0;
+    font-size: 7vh;
+}
+
+div#metro > div.subtitle {
+    column-span: all;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    & > h4 {
+        font-size: 5vh;
+        background-color: #333;
+        color: #fff;
+    }
+}
+
+div#metro {
+    & > div {
+        background-color: #333;
+        padding: 0 2vw 0 1vw;
+        display: grid;
+        grid-template-columns: 5vw 1fr;
+        position: relative;
+    }
+
+    & > div:nth-child(odd) {
+        background-color: #222; /* TODO: maybe change to better color */
+    }
+
+    & span {
+        font-size: 5vh;
+        color: #fff;
+    }
+}
+
+div#tram {
+    & > div {
+        background-color: #333;
+        padding: 0 1vw 0 2vw;
+        display: grid;
+        grid-template-columns: 5vw 1fr;
+        position: relative;
+    }
+
+    & > div:nth-child(odd) {
+        background-color: #222; /* TODO: maybe change to better color */
+    }
+
+    & span {
+        font-size: 5vh;
+        color: #fff;
+    }
+}
+
+span.dest {
+    padding-left: 2vw;
+    display: inline-block;
+}
+
+span.time {
+    padding-right: 2vw;
+    position: absolute;
+    right: 0;
+}
+
+span.linenr {
+    width: 5vw;
+    display: inline-block;
+    padding: 0 1vw;
+}

--- a/public/css/metro-tram.css
+++ b/public/css/metro-tram.css
@@ -25,7 +25,6 @@ div#metro > div.subtitle {
 
     & > h4 {
         font-size: 5vh;
-        background-color: #333;
         color: #fff;
     }
 }

--- a/public/css/metro-tram.css
+++ b/public/css/metro-tram.css
@@ -34,7 +34,7 @@ div#metro {
         background-color: #333;
         padding: 0 2vw 0 1vw;
         display: grid;
-        grid-template-columns: 5vw 1fr;
+        grid-template-columns: 6vw 1fr;
         position: relative;
     }
 
@@ -53,7 +53,7 @@ div#tram {
         background-color: #333;
         padding: 0 1vw 0 2vw;
         display: grid;
-        grid-template-columns: 5vw 1fr;
+        grid-template-columns: 6vw 1fr;
         position: relative;
     }
 
@@ -65,6 +65,10 @@ div#tram {
         font-size: 5vh;
         color: #fff;
     }
+
+    & span.time {
+        right: 1vw;
+    }
 }
 
 span.dest {
@@ -73,13 +77,10 @@ span.dest {
 }
 
 span.time {
-    padding-right: 2vw;
+    right: 2vw;
     position: absolute;
-    right: 0;
 }
 
 span.linenr {
-    width: 5vw;
     display: inline-block;
-    padding: 0 1vw;
 }

--- a/views/metro-tram.html
+++ b/views/metro-tram.html
@@ -20,7 +20,6 @@
         });
         events.addEventListener('slmetro', (metro) => {
           const data = JSON.parse(metro.data);
-          console.log("Fippel", data)
           metrohtml = '<h3> Metro </h3>'
           metrohtml += '<div class="subtitle"><h4> North </h4></div>';
           data.north.forEach((metro, index) => {

--- a/views/metro-tram.html
+++ b/views/metro-tram.html
@@ -20,7 +20,7 @@
         });
         events.addEventListener('slmetro', (metro) => {
           const data = JSON.parse(metro.data);
-          metrohtml = '<h3> Metro </h3>'
+          let metrohtml = '<h3> Metro </h3>'
           metrohtml += '<div class="subtitle"><h4> North </h4></div>';
           data.north.forEach((metro, index) => {
             metrohtml += `<div><span class='linenr'>${metro.id}</span><span class='dest'>${metro.destination}</span> <span class='time'>${metro.display}</span></div>`;
@@ -29,7 +29,7 @@
           data.south.forEach((metro, index) => {
             metrohtml += `<div><span class='linenr'>${metro.id}</span><span class='dest'>${metro.destination}</span> <span class='time'>${metro.display}</span></div>`;
           });
-          document.getElementById("metro").innerHTML = metrohtml;s
+          document.getElementById("metro").innerHTML = metrohtml;
           document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
         });
         events.addEventListener('open', () => {

--- a/views/metro-tram.html
+++ b/views/metro-tram.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title> Metasl2.0 - Metro & Tram</title>
+    <link rel="stylesheet" href="/public/css/common.css">
+    <link rel="stylesheet" href="/public/css/metro-tram.css">
+    <script>
+      let events;
+      let backoff = 1;
+      function setupEvents() {
+        events = new EventSource('/subscribe');
+        events.addEventListener('sltram', (tram) => {
+          const data = JSON.parse(tram.data);
+          let tramhtml = '<h3> Roslagsbanan </h3>'
+          data.forEach((tram) => {
+            tramhtml += `<div><span class='linenr'>${tram.id}</span><span class='dest'>${tram.destination}</span> <span class='time'>${tram.display}</span></div>`;
+          });
+          document.getElementById("tram").innerHTML = tramhtml;
+          document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
+        });
+        events.addEventListener('slmetro', (metro) => {
+          const data = JSON.parse(metro.data);
+          console.log("Fippel", data)
+          metrohtml = '<h3> Metro </h3>'
+          metrohtml += '<div class="subtitle"><h4> North </h4></div>';
+          data.north.forEach((metro, index) => {
+            metrohtml += `<div><span class='linenr'>${metro.id}</span><span class='dest'>${metro.destination}</span> <span class='time'>${metro.display}</span></div>`;
+          });
+          metrohtml += '<div class="subtitle"><h4> South </h4></div>';
+          data.south.forEach((metro, index) => {
+            metrohtml += `<div><span class='linenr'>${metro.id}</span><span class='dest'>${metro.destination}</span> <span class='time'>${metro.display}</span></div>`;
+          });
+          document.getElementById("metro").innerHTML = metrohtml;s
+          document.querySelector("#last-update").innerText = new Date().toLocaleString("sv-SE", { timeZone: "Europe/Stockholm", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
+        });
+        events.addEventListener('open', () => {
+          backoff = 1;
+        });
+        events.addEventListener('error', () => {
+          // Manually handle errors because it doesn't retry on 502
+          events.close();
+          setTimeout(setupEvents, backoff * 1000);
+          backoff = Math.min(backoff * 2, 60);
+        });
+      }
+
+      setupEvents();
+    </script>
+  </head>
+  <body>
+    <div class="container">
+      <div id='metro'>
+        <h3> Metro </h3>
+        <div class='subtitle'><h4> North </h4></div>
+        <div><span class='linenr'>14</span><span class='dest'> Mörby centrum </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>14</span><span class='dest'> Mörby centrum </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>14</span><span class='dest'> Mörby centrum </span> <span class='time'> 42min </span></div>
+        <div class='subtitle'><h4> South </h4></div>
+        <div><span class='linenr'>14</span><span class='dest'> Liljeholmen </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>14</span><span class='dest'> Fruängen </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>14</span><span class='dest'> Liljeholmen </span> <span class='time'> 42min </span></div>
+      </div>
+      <div id='tram'>
+        <h3> Roslagsbanan </h3>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+        <div><span class='linenr'>42</span><span class='dest'> Täby Någonstans </span> <span class='time'> 42min </span></div>
+      </div>
+    </div>
+    <div class="updated-at">
+      Datan hämtades senast <span id="last-update"></span>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds a new page `/metro-tram` that shows the metro and the tram on the same page. METAClock will now only have to loop thru two pages to show all departures, which means less wait time for METApeople! ⌛ 
<img width="1470" alt="Screenshot 2025-04-21 at 21 08 09" src="https://github.com/user-attachments/assets/3aec0e2c-23ac-44f6-bd9f-26b30b01555b" />